### PR TITLE
fix fs metrics npe

### DIFF
--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -497,7 +497,7 @@ public class PrometheusMetricsCollector {
             catalog.setGauge("fs_total_total_bytes", fs.getTotal().getTotal().bytes(), node);
             catalog.setGauge("fs_total_available_bytes", fs.getTotal().getAvailable().bytes(), node);
             catalog.setGauge("fs_total_free_bytes", fs.getTotal().getFree().bytes(), node);
-            if (fs.getTotal().getSpins() != null)
+            if (fs.getTotal() != null && fs.getTotal().getSpins() != null)
                 catalog.setGauge("fs_total_is_spinning_bool", fs.getTotal().getSpins() ? 1 : 0, node);
 
             for (FsInfo.Path fspath : fs) {


### PR DESCRIPTION
On a balancer node( not master, not data node), `fs.getTotal` is null. 
`GET /_nodes/stats/fs HTTP/1.1` will get something like:
```json
 "fs": {
        "timestamp": 1477461567785,
        "total": {},
        "data": []
      }
```
