### PR TITLE
Enable support for ES 5.0.0

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -34,7 +34,7 @@
 description=Prometheus Exporter
 #
 # 'version': plugin's version
-version=2.4.1.0
+version=5.0.0
 #
 # 'name': the plugin name
 name=prometheus-exporter
@@ -68,13 +68,5 @@ java.version=1.8
 # elasticsearch release. This version is checked when the plugin
 # is loaded so Elasticsearch will refuse to start in the presence of
 # plugins with the incorrect elasticsearch.version.
-elasticsearch.version=2.4.1
-#
-### deprecated elements for jvm plugins :
-#
-# 'isolated': true if the plugin should have its own classloader.
-# passing false is deprecated, and only intended to support plugins 
-# that have hard dependencies against each other. If this is
-# not specified, then the plugin is isolated by default.
-isolated=false
+elasticsearch.version=5.0.0
 #

--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -1,4 +1,5 @@
 grant {
     permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
     permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
 };

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </scm>
 
     <properties>
-        <elasticsearch.version>2.4.1</elasticsearch.version>
+        <elasticsearch.version>5.0.0</elasticsearch.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -47,6 +47,12 @@
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_common</artifactId>
             <version>0.0.15</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.6.2</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -8,7 +8,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.basedir}</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>/elasticsearch</outputDirectory>
             <includes>
                 <include>plugin-descriptor.properties</include>
                 <include>plugin-security.policy</include>
@@ -17,7 +17,7 @@
     </fileSets>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>/elasticsearch</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>
@@ -25,7 +25,7 @@
             </excludes>
         </dependencySet>
         <dependencySet>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>/elasticsearch</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <includes>

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCatalog.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCatalog.java
@@ -5,7 +5,7 @@ import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Summary;
 import io.prometheus.client.exporter.common.TextFormat;
-import org.elasticsearch.common.logging.ESLogger;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.rest.prometheus.RestPrometheusMetricsAction;
 
@@ -14,22 +14,25 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.HashMap;
 
-public class PrometheusMetricsCatalog {
-    private final static ESLogger logger = ESLoggerFactory.getLogger(RestPrometheusMetricsAction.class.getSimpleName());
+public class PrometheusMetricsCatalog
+{
+    private final static Logger logger = ESLoggerFactory.getLogger(RestPrometheusMetricsAction.class.getSimpleName());
 
     private String cluster;
     private String metric_prefix;
     private HashMap metrics;
     private CollectorRegistry registry;
 
-    public PrometheusMetricsCatalog(String cluster, String metric_prefix) {
+    public PrometheusMetricsCatalog(String cluster, String metric_prefix)
+    {
         this.cluster = cluster;
         this.metric_prefix = metric_prefix;
         metrics = new HashMap();
         registry = new CollectorRegistry();
     }
 
-    private String[] getExtendedLabelNames(String... label_names) {
+    private String[] getExtendedLabelNames(String... label_names)
+    {
         String[] extended = new String[label_names.length + 1];
         extended[0] = "cluster";
 
@@ -38,7 +41,8 @@ public class PrometheusMetricsCatalog {
         return extended;
     }
 
-    private String[] getExtendedLabelValues(String... label_values) {
+    private String[] getExtendedLabelValues(String... label_values)
+    {
         String[] extended = new String[label_values.length + 1];
         extended[0] = cluster;
 
@@ -47,7 +51,8 @@ public class PrometheusMetricsCatalog {
         return extended;
     }
 
-    public void registerGauge(String metric, String help, String... labels) {
+    public void registerGauge(String metric, String help, String... labels)
+    {
         Gauge gauge = Gauge.build().
                 name(metric_prefix + metric).
                 help(help).
@@ -59,12 +64,14 @@ public class PrometheusMetricsCatalog {
         logger.debug(String.format("Registered new gauge %s", metric));
     }
 
-    public void setGauge(String metric, double value, String... label_values) {
+    public void setGauge(String metric, double value, String... label_values)
+    {
         Gauge gauge = (Gauge) metrics.get(metric);
         gauge.labels(getExtendedLabelValues(label_values)).set(value);
     }
 
-    public void registerCounter(String metric, String help, String... labels) {
+    public void registerCounter(String metric, String help, String... labels)
+    {
         Counter counter = Counter.build().
                 name(metric_prefix + metric).
                 help(help).
@@ -76,20 +83,25 @@ public class PrometheusMetricsCatalog {
         logger.debug(String.format("Registered new counter %s", metric));
     }
 
-    public void setCounter(String metric, double value, String... label_values) {
+    public void setCounter(String metric, double value, String... label_values)
+    {
         String[] extended_label_values = getExtendedLabelValues(label_values);
         Counter counter = (Counter) metrics.get(metric);
 
         double increment = value - counter.labels(extended_label_values).get();
 
-        if (increment >= 0) {
+        if (increment >= 0)
+        {
             counter.labels(extended_label_values).inc(increment);
-        } else {
+        }
+        else
+        {
             logger.error(String.format("Can not increment metric %s with value %f, skipping", metric, increment));
         }
     }
 
-    public void registerSummaryTimer(String metric, String help, String... labels) {
+    public void registerSummaryTimer(String metric, String help, String... labels)
+    {
         Summary summary = Summary.build().
                 name(metric_prefix + metric).
                 help(help).
@@ -101,17 +113,22 @@ public class PrometheusMetricsCatalog {
         logger.debug(String.format("Registered new summary %s", metric));
     }
 
-    public Summary.Timer startSummaryTimer(String metric, String... label_values) {
+    public Summary.Timer startSummaryTimer(String metric, String... label_values)
+    {
         Summary summary = (Summary) metrics.get(metric);
         return summary.labels(getExtendedLabelValues(label_values)).startTimer();
     }
 
-    public String toTextFormat() throws IOException {
-        try {
+    public String toTextFormat() throws IOException
+    {
+        try
+        {
             Writer writer = new StringWriter();
             TextFormat.write004(writer, registry.metricFamilySamples());
             return writer.toString();
-        } catch (IOException e) {
+        }
+        catch (IOException e)
+        {
             throw e;
         }
     }

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -408,7 +408,9 @@ public class PrometheusMetricsCollector {
 
     private void registerOsMetrics() {
         catalog.registerGauge("os_cpu_percent", "CPU usage in percent", "node");
-        catalog.registerGauge("os_load_average", "CPU load", "node");
+        catalog.registerGauge("os_load_average_one_minute", "CPU load", "node");
+        catalog.registerGauge("os_load_average_five_minutes", "CPU load", "node");
+        catalog.registerGauge("os_load_average_fifteen_minutes", "CPU load", "node");
         catalog.registerGauge("os_mem_free_bytes", "Memory free", "node");
         catalog.registerGauge("os_mem_free_percent", "Memory free in percent", "node");
         catalog.registerGauge("os_mem_used_bytes", "Memory used", "node");

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -426,7 +426,7 @@ public class PrometheusMetricsCollector {
             catalog.setGauge("os_cpu_percent", os.getCpu().getPercent(), node);
             catalog.setGauge("os_load_average_one_minute", os.getCpu().getLoadAverage()[0], node);
             catalog.setGauge("os_load_average_five_minutes", os.getCpu().getLoadAverage()[1], node);
-            catalog.setGauge("os_load_average_fifteen_minutes", os.getCpu().getLoadAverage()[3], node);
+            catalog.setGauge("os_load_average_fifteen_minutes", os.getCpu().getLoadAverage()[2], node);
             catalog.setGauge("os_mem_free_bytes", os.getMem().getFree().getBytes(), node);
             catalog.setGauge("os_mem_free_percent", os.getMem().getFreePercent(), node);
             catalog.setGauge("os_mem_used_bytes", os.getMem().getUsed().getBytes(), node);

--- a/src/main/java/org/elasticsearch/plugin/prometheus/PrometheusExporterPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/prometheus/PrometheusExporterPlugin.java
@@ -1,35 +1,43 @@
 package org.elasticsearch.plugin.prometheus;
 
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.rest.RestModule;
+import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.rest.prometheus.RestPrometheusMetricsAction;
 
-public class PrometheusExporterPlugin extends Plugin {
+import java.util.List;
 
-    private final ESLogger logger = Loggers.getLogger(PrometheusExporterPlugin.class);
+import static java.util.Collections.singletonList;
+
+public class PrometheusExporterPlugin extends Plugin implements ActionPlugin
+{
+
+    private final Logger logger = Loggers.getLogger(PrometheusExporterPlugin.class);
+
     private Settings settings;
 
     @Inject
-    public PrometheusExporterPlugin(Settings settings) {
+    public PrometheusExporterPlugin(Settings settings)
+    {
         this.settings = settings;
         logger.info("starting Prometheus exporter plugin...");
     }
 
     @Override
-    public String name() {
-        return "prometheus-exporter";
+    public void onIndexModule(IndexModule indexModule)
+    {
+        super.onIndexModule(indexModule);
     }
 
     @Override
-    public String description() {
-        return "Prometheus Exporter Plugin";
+    public List<Class<? extends RestHandler>> getRestHandlers()
+    {
+        return singletonList(RestPrometheusMetricsAction.class);
     }
 
-    public void onModule(RestModule module) {
-        module.addRestAction(RestPrometheusMetricsAction.class);
-    }
 }


### PR DESCRIPTION
This PR enables support for ES 5.0.0

We need to address the following issues:

- Percolator is deprecated in 5.0 . Figure out if there are stats for the new "percolate query" to export

- getIndexWriterMaxMemoryInBytes not avaivable in 5.0

- index. getSuggest() not  avaivable in 5.0

Otherwise everything seems to be working properly
