### PR TITLE
drop invalid properties in plugin descriptor

### DIFF
--- a/src/main/templates/plugin-descriptor.properties
+++ b/src/main/templates/plugin-descriptor.properties
@@ -1,8 +1,6 @@
 description=${descriptor.description}
 version=${descriptor.version}
 name=${descriptor.name}
-site=false
-jvm=true
 classname=${descriptor.classname}
 java.version=${descriptor.javaVersion}
 elasticsearch.version=${descriptor.elasticsearchVersion}


### PR DESCRIPTION
Fixes #87 .
Tested by installing and probing /_prometheus/metrics

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vvanholl/elasticsearch-prometheus-exporter/88)
<!-- Reviewable:end -->
