### PR TITLE
Expose cluster settings as metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
     - File System
     - Circuit Breaker
 - Indices status
+- Cluster settings (selected [disk allocation settings](https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html) only)
 
 ## Compatibility matrix
 
@@ -124,6 +125,11 @@ If you have a lot of indices and think this data is irrelevant, you can disable 
 prometheus.indices: false
 ```
 
+To disable exporting cluster settings use:
+```
+prometheus.cluster.settings: false
+```
+
 ## Uninstall
 
 - Since Elasticsearch 6.0.0:
@@ -193,6 +199,24 @@ Just keep in mind that `metrics_path` must be `/_prometheus/metrics`, otherwise 
 ## Project sources
 
 The Maven project site is available at [GitHub](https://github.com/vvanholl/elasticsearch-prometheus-exporter).
+
+## Testing
+
+Project contains [integration tests](src/test/resources/rest-api-spec) implemented using
+[rest layer](https://github.com/elastic/elasticsearch/blob/master/TESTING.asciidoc#testing-the-rest-layer)
+framework.
+
+Complete test suite is run using:
+```
+gradle clean check
+```
+
+To run individual test file use:
+```
+gradle :integTest \
+  -Dtests.class=org.elasticsearch.rest.PrometheusRestHandlerClientYamlTestSuiteIT \
+  -Dtests.method="test {yaml=resthandler/20_metrics/Prometheus metrics can be pulled}"
+```
 
 ## Credits
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,12 @@ apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'elasticsearch.esplugin'
 
+// Uncomment if you want to use: System.out.println("Emergency!");
+// Logs are found in build/cluster/integTestCluster*/cwd/run.log
+//forbiddenApis {
+//    ignoreFailures = true
+//}
+
 // license of this project
 licenseFile = rootProject.file('LICENSE.txt')
 // copyright notices

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -17,6 +17,7 @@
 
 package org.compuscene.metrics.prometheus;
 
+import org.elasticsearch.action.ClusterStatsData;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
@@ -47,8 +48,15 @@ import io.prometheus.client.Summary;
  * A class that describes a Prometheus metrics collector.
  */
 public class PrometheusMetricsCollector {
-    public static final Setting<Boolean> PROMETHEUS_INDICES = Setting.boolSetting("prometheus.indices", true,
-            Property.NodeScope);
+    // These settings become part of cluster state, it is avail via HTTP at
+    // curl <elasticsearch>/_cluster/settings?include_defaults=true&filter_path=defaults.prometheus
+    // It is thus important to keep them under reasonable namespace to avoid collision with
+    // other plugins or future/commercial parts of Elastic Stack itself.
+    // Namespace "prometheus" sounds like safe bet for now.
+    public static final Setting<Boolean> PROMETHEUS_CLUSTER_SETTINGS = Setting.boolSetting("prometheus.cluster.settings",
+            true, Property.NodeScope);
+    public static final Setting<Boolean> PROMETHEUS_INDICES = Setting.boolSetting("prometheus.indices",
+            true, Property.NodeScope);
 
     private final Settings settings;
 
@@ -78,6 +86,9 @@ public class PrometheusMetricsCollector {
         registerJVMMetrics();
         registerOsMetrics();
         registerFsMetrics();
+        if (PROMETHEUS_CLUSTER_SETTINGS.get(settings)) {
+            registerESSettings();
+        }
     }
 
     private void registerClusterMetrics() {
@@ -882,8 +893,39 @@ public class PrometheusMetricsCollector {
         }
     }
 
+    @SuppressWarnings("checkstyle:LineLength")
+    private void registerESSettings() {
+        catalog.registerClusterGauge("cluster_routing_allocation_disk_threshold_enabled", "Disk allocation decider is enabled");
+        //
+        catalog.registerClusterGauge("cluster_routing_allocation_disk_watermark_low_bytes", "Low watermark for disk usage in bytes");
+        catalog.registerClusterGauge("cluster_routing_allocation_disk_watermark_high_bytes", "High watermark for disk usage in bytes");
+        catalog.registerClusterGauge("cluster_routing_allocation_disk_watermark_flood_stage_bytes", "Flood stage for disk usage in bytes");
+        //
+        catalog.registerClusterGauge("cluster_routing_allocation_disk_watermark_low_pct", "Low watermark for disk usage in pct");
+        catalog.registerClusterGauge("cluster_routing_allocation_disk_watermark_high_pct", "High watermark for disk usage in pct");
+        catalog.registerClusterGauge("cluster_routing_allocation_disk_watermark_flood_stage_pct", "Flood stage watermark for disk usage in pct");
+    }
+
+    @SuppressWarnings({"checkstyle:LineLength", "checkstyle:LeftCurly"})
+    private void updateESSettings(ClusterStatsData stats) {
+        if (stats != null) {
+            catalog.setClusterGauge("cluster_routing_allocation_disk_threshold_enabled", Boolean.TRUE.equals(stats.getThresholdEnabled()) ? 1 : 0);
+            // According to Elasticsearch documentation the following settings must be set either in pct or bytes size.
+            // Mixing is not allowed. We rely on Elasticsearch to do all necessary checks and we simply
+            // output all those metrics that are not null. If this will lead to mixed metric then we do not
+            // consider it our fault.
+            if (stats.getDiskLowInBytes() != null) { catalog.setClusterGauge("cluster_routing_allocation_disk_watermark_low_bytes", stats.getDiskLowInBytes()); }
+            if (stats.getDiskHighInBytes() != null) { catalog.setClusterGauge("cluster_routing_allocation_disk_watermark_high_bytes", stats.getDiskHighInBytes()); }
+            if (stats.getFloodStageInBytes() != null) { catalog.setClusterGauge("cluster_routing_allocation_disk_watermark_flood_stage_bytes", stats.getFloodStageInBytes()); }
+            //
+            if (stats.getDiskLowInPct() != null) { catalog.setClusterGauge("cluster_routing_allocation_disk_watermark_low_pct", stats.getDiskLowInPct()); }
+            if (stats.getDiskHighInPct() != null) { catalog.setClusterGauge("cluster_routing_allocation_disk_watermark_high_pct", stats.getDiskHighInPct()); }
+            if (stats.getFloodStageInPct() != null) { catalog.setClusterGauge("cluster_routing_allocation_disk_watermark_flood_stage_pct", stats.getFloodStageInPct()); }
+        }
+    }
+
     public void updateMetrics(ClusterHealthResponse clusterHealthResponse, NodeStats nodeStats,
-                              IndicesStatsResponse indicesStats) {
+                              IndicesStatsResponse indicesStats, ClusterStatsData clusterStatsData) {
         Summary.Timer timer = catalog.startSummaryTimer("metrics_generate_time_seconds");
 
         updateClusterMetrics(clusterHealthResponse);
@@ -902,6 +944,9 @@ public class PrometheusMetricsCollector {
         updateJVMMetrics(nodeStats.getJvm());
         updateOsMetrics(nodeStats.getOs());
         updateFsMetrics(nodeStats.getFs());
+        if (PROMETHEUS_CLUSTER_SETTINGS.get(settings)) {
+            updateESSettings(clusterStatsData);
+        }
 
         timer.observeDuration();
     }

--- a/src/main/java/org/elasticsearch/action/ClusterStatsData.java
+++ b/src/main/java/org/elasticsearch/action/ClusterStatsData.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright [2018] [Vincent VAN HOLLEBEKE]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.elasticsearch.action;
+
+import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.*;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsException;
+
+import java.io.IOException;
+
+
+/**
+ * Selected settings from Elasticsearch cluster settings.
+ *
+ * Disk-based shard allocation [1] settings play important role in how Elasticsearch decides where to allocate
+ * new shards or if existing shards are relocated to different nodes. The tricky part about these settings is
+ * that they can be expressed either in percent or bytes value (they cannot be mixed) and they can be updated on the fly.
+ *
+ * [1] https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html#disk-allocator
+ *
+ * In order to make it easy for Prometheus to consume the data we expose these settings in both formats (pct and bytes)
+ * and we do our best in determining if they are currently set as pct or bytes filling appropriate variables with data
+ * or null value.
+ */
+public class ClusterStatsData extends ActionResponse {
+
+    private Boolean thresholdEnabled = null;
+
+    @Nullable private Long diskLowInBytes;
+    @Nullable private Long diskHighInBytes;
+    @Nullable private Long floodStageInBytes;
+
+    @Nullable private Double diskLowInPct;
+    @Nullable private Double diskHighInPct;
+    @Nullable private Double floodStageInPct;
+
+    private Long[] diskLowInBytesRef = new Long[]{diskLowInBytes};
+    private Long[] diskHighInBytesRef = new Long[]{diskHighInBytes};
+    private Long[] floodStageInBytesRef = new Long[]{floodStageInBytes};
+
+    private Double[] diskLowInPctRef = new Double[]{diskLowInPct};
+    private Double[] diskHighInPctRef = new Double[]{diskHighInPct};
+    private Double[] floodStageInPctRef = new Double[]{floodStageInPct};
+
+
+    public ClusterStatsData(ClusterStateResponse clusterStateResponse, Settings settings, ClusterSettings clusterSettings) {
+
+        MetaData m = clusterStateResponse.getState().getMetaData();
+        // There are several layers of cluster settings in Elasticsearch each having different priority.
+        // We need to traverse them from the top priority down to find relevant value of each setting.
+        // See https://www.elastic.co/guide/en/elasticsearch/reference/master/cluster-update-settings.html#_order_of_precedence
+        for (Settings s : new Settings[]{
+                // See: RestClusterGetSettingsAction#response
+                // or: https://github.com/elastic/elasticsearch/pull/33247/files
+                // We do not filter the settings, but we use the clusterSettings.diff()
+                // In the end we expose just a few selected settings ATM.
+                m.transientSettings(),
+                m.persistentSettings(),
+                clusterSettings.diff(m.settings(), settings)
+        }) {
+            thresholdEnabled = thresholdEnabled == null ?
+                    s.getAsBoolean(CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), null) : thresholdEnabled;
+
+            parseValue(s, CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), diskLowInBytesRef, diskLowInPctRef);
+            parseValue(s, CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), diskHighInBytesRef, diskHighInPctRef);
+            parseValue(s, CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), floodStageInBytesRef, floodStageInPctRef);
+        }
+
+        diskLowInBytes = diskLowInBytesRef[0];
+        diskHighInBytes = diskHighInBytesRef[0];
+        floodStageInBytes = floodStageInBytesRef[0];
+
+        diskLowInPct = diskLowInPctRef[0];
+        diskHighInPct = diskHighInPctRef[0];
+        floodStageInPct = floodStageInPctRef[0];
+    }
+
+    /**
+     * Try to extract and parse value from settings for given key.
+     * First it tries to parse it as a RatioValue (pct) then as byte size value.
+     * It assigns parsed value to corresponding argument references (passed via array hack).
+     * If parsing fails the method fires exception, however, this should not happen - we rely on Elasticsearch
+     * to already have parsed and validated these values before. Unless we screwed something up...
+     */
+    private void parseValue(Settings s, String key, Long[] bytesPointer, Double[] pctPointer) {
+        String value = s.get(key);
+        if (value != null && pctPointer[0] == null) {
+            try {
+                pctPointer[0] = s.getAsRatio(key, null).getAsPercent();
+            } catch (SettingsException | ElasticsearchParseException | NullPointerException e1) {
+                if (bytesPointer[0] == null) {
+                    try {
+                        bytesPointer[0] = s.getAsBytesSize(key, null).getBytes();
+                    } catch (SettingsException | ElasticsearchParseException | NullPointerException e2) {
+                        // TODO: log.debug("This went wrong, but 'Keep Calm and Carry On'")
+                        // We should avoid using logs in this class (due to perf impact), instead we should
+                        // consider moving this logic to some static helper class/method going forward.
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        thresholdEnabled = in.readOptionalBoolean();
+        //
+        diskLowInBytes = in.readOptionalLong();
+        diskHighInBytes = in.readOptionalLong();
+        floodStageInBytes = in.readOptionalLong();
+        //
+        diskLowInPct = in.readOptionalDouble();
+        diskHighInPct = in.readOptionalDouble();
+        floodStageInPct = in.readOptionalDouble();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalBoolean(thresholdEnabled);
+        //
+        out.writeOptionalLong(diskLowInBytes);
+        out.writeOptionalLong(diskHighInBytes);
+        out.writeOptionalLong(floodStageInBytes);
+        //
+        out.writeOptionalDouble(diskLowInPct);
+        out.writeOptionalDouble(diskHighInPct);
+        out.writeOptionalDouble(floodStageInPct);
+    }
+
+    public Boolean getThresholdEnabled() {
+        return thresholdEnabled;
+    }
+
+    @Nullable
+    public Long getDiskLowInBytes() {
+        return diskLowInBytes;
+    }
+
+    @Nullable
+    public Long getDiskHighInBytes() {
+        return diskHighInBytes;
+    }
+
+    @Nullable
+    public Long getFloodStageInBytes() {
+        return floodStageInBytes;
+    }
+
+    @Nullable
+    public Double getDiskLowInPct() {
+        return diskLowInPct;
+    }
+
+    @Nullable
+    public Double getDiskHighInPct() {
+        return diskHighInPct;
+    }
+
+    @Nullable
+    public Double getFloodStageInPct() {
+        return floodStageInPct;
+    }
+}

--- a/src/main/java/org/elasticsearch/action/TransportNodePrometheusMetricsAction.java
+++ b/src/main/java/org/elasticsearch/action/TransportNodePrometheusMetricsAction.java
@@ -17,6 +17,7 @@
 
 package org.elasticsearch.action;
 
+import static org.compuscene.metrics.prometheus.PrometheusMetricsCollector.PROMETHEUS_CLUSTER_SETTINGS;
 import static org.compuscene.metrics.prometheus.PrometheusMetricsCollector.PROMETHEUS_INDICES;
 
 import org.elasticsearch.ElasticsearchException;
@@ -24,6 +25,8 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.support.ActionFilters;
@@ -33,24 +36,34 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 /**
  * Transport action class for Prometheus Exporter plugin.
+ *
+ * It performs several requests within the cluster to gather "cluster health", "nodes stats", "indices stats"
+ * and "cluster state" (i.e. cluster settings) info. Some of those requests are optional depending on plugin
+ * settings.
  */
 public class TransportNodePrometheusMetricsAction extends HandledTransportAction<NodePrometheusMetricsRequest,
         NodePrometheusMetricsResponse> {
     private final Client client;
+    private final Settings settings;
+    private final ClusterSettings clusterSettings;
 
     @Inject
     public TransportNodePrometheusMetricsAction(Settings settings, ThreadPool threadPool, Client client,
                                                 TransportService transportService, ActionFilters actionFilters,
-                                                IndexNameExpressionResolver indexNameExpressionResolver) {
+                                                IndexNameExpressionResolver indexNameExpressionResolver,
+                                                ClusterSettings clusterSettings) {
         super(settings, NodePrometheusMetricsAction.NAME, threadPool, transportService, actionFilters,
                 indexNameExpressionResolver, NodePrometheusMetricsRequest::new);
         this.client = client;
+        this.settings = settings;
+        this.clusterSettings = clusterSettings;
     }
 
     @Override
@@ -59,13 +72,29 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
     }
 
     private class AsyncAction {
+
         private final ActionListener<NodePrometheusMetricsResponse> listener;
+
         private final ClusterHealthRequest healthRequest;
         private final NodesStatsRequest nodesStatsRequest;
         private final IndicesStatsRequest indicesStatsRequest;
-        private ClusterHealthResponse clusterHealthResponse;
-        private NodesStatsResponse nodesStatsResponse;
+        private final ClusterStateRequest clusterStateRequest;
 
+        private ClusterHealthResponse clusterHealthResponse = null;
+        private NodesStatsResponse nodesStatsResponse = null;
+        private IndicesStatsResponse indicesStatsResponse = null;
+        private ClusterStateResponse clusterStateResponse = null;
+
+        // All the requests are executed in sequential non-blocking order.
+        // It is implemented by wrapping each individual request with ActionListener
+        // and chaining all of them into a sequence. The last member of the chain call method that gathers
+        // all the responses from previous requests and pass them to outer listener (i.e. calling client).
+        // Optional requests are skipped.
+        //
+        // In the future we might consider executing all the requests in parallel if needed (CountDownLatch?),
+        // however, some of the requests can impact cluster performance (especially if the cluster is already overloaded)
+        // and in this situation it is better to run all requests in predictable order so that collected metrics
+        // stay consistent.
         private AsyncAction(ActionListener<NodePrometheusMetricsResponse> listener) {
             this.listener = listener;
 
@@ -77,54 +106,85 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
             this.healthRequest.level(ClusterHealthRequest.Level.SHARDS);
 
             this.nodesStatsRequest = Requests.nodesStatsRequest("_local").clear().all();
-            // Note: this request is not "node-specific", it does not support any "_local" notion
+
+            // Indices stats request is not "node-specific", it does not support any "_local" notion
             // it is broad-casted to all cluster nodes.
-            this.indicesStatsRequest = new IndicesStatsRequest();
+            this.indicesStatsRequest = PROMETHEUS_INDICES.get(settings) ? new IndicesStatsRequest() : null;
+
+            // Cluster settings are get via ClusterStateRequest (see elasticsearch RestClusterGetSettingsAction for details)
+            // We prefer to send it to master node (hence local=false; it should be set by default but we want to be sure).
+            this.clusterStateRequest = PROMETHEUS_CLUSTER_SETTINGS.get(settings) ? Requests.clusterStateRequest()
+                    .clear().metaData(true).local(false) : null;
         }
 
-        private ActionListener<IndicesStatsResponse> indicesStatsResponseActionListener =
-                new ActionListener<IndicesStatsResponse>() {
-            @Override
-            public void onResponse(IndicesStatsResponse indicesStatsResponse) {
-                listener.onResponse(buildResponse(clusterHealthResponse, nodesStatsResponse, indicesStatsResponse));
-            }
+        private void gatherRequests() {
+            listener.onResponse(buildResponse(clusterHealthResponse, nodesStatsResponse, indicesStatsResponse,
+                    clusterStateResponse));
+        }
 
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(new ElasticsearchException("Indices stats request failed", e));
-            }
-        };
-
-        private ActionListener<NodesStatsResponse> nodesStatsResponseActionListener = new ActionListener<NodesStatsResponse>() {
-            @Override
-            public void onResponse(NodesStatsResponse nodeStats) {
-                if (PROMETHEUS_INDICES.get(settings)) {
-                    nodesStatsResponse = nodeStats;
-                    client.admin().indices().stats(indicesStatsRequest, indicesStatsResponseActionListener);
-                } else {
-                    listener.onResponse(buildResponse(clusterHealthResponse, nodeStats, null));
+        private ActionListener<ClusterStateResponse> clusterStateResponseActionListener =
+            new ActionListener<ClusterStateResponse>() {
+                @Override
+                public void onResponse(ClusterStateResponse response) {
+                    clusterStateResponse = response;
+                    gatherRequests();
                 }
-            }
 
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(new ElasticsearchException("Nodes stats request failed", e));
-            }
-        };
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(new ElasticsearchException("Cluster state request failed", e));
+                }
+            };
+
+        private ActionListener<IndicesStatsResponse> indicesStatsResponseActionListener =
+            new ActionListener<IndicesStatsResponse>() {
+                @Override
+                public void onResponse(IndicesStatsResponse response) {
+                    indicesStatsResponse = response;
+                    if (PROMETHEUS_CLUSTER_SETTINGS.get(settings)) {
+                        client.admin().cluster().state(clusterStateRequest, clusterStateResponseActionListener);
+                    } else {
+                        gatherRequests();
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(new ElasticsearchException("Indices stats request failed", e));
+                }
+            };
+
+        private ActionListener<NodesStatsResponse> nodesStatsResponseActionListener =
+            new ActionListener<NodesStatsResponse>() {
+                @Override
+                public void onResponse(NodesStatsResponse nodeStats) {
+                    nodesStatsResponse = nodeStats;
+                    if (PROMETHEUS_INDICES.get(settings)) {
+                        client.admin().indices().stats(indicesStatsRequest, indicesStatsResponseActionListener);
+                    } else {
+                        indicesStatsResponseActionListener.onResponse(null);
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(new ElasticsearchException("Nodes stats request failed", e));
+                }
+            };
 
         private ActionListener<ClusterHealthResponse> clusterHealthResponseActionListener =
-                new ActionListener<ClusterHealthResponse>() {
-            @Override
-            public void onResponse(ClusterHealthResponse response) {
-                clusterHealthResponse = response;
-                client.admin().cluster().nodesStats(nodesStatsRequest, nodesStatsResponseActionListener);
-            }
+            new ActionListener<ClusterHealthResponse>() {
+                @Override
+                public void onResponse(ClusterHealthResponse response) {
+                    clusterHealthResponse = response;
+                    client.admin().cluster().nodesStats(nodesStatsRequest, nodesStatsResponseActionListener);
+                }
 
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(new ElasticsearchException("Cluster health request failed", e));
-            }
-        };
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(new ElasticsearchException("Cluster health request failed", e));
+                }
+            };
 
         private void start() {
             client.admin().cluster().health(healthRequest, clusterHealthResponseActionListener);
@@ -132,9 +192,11 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
 
         protected NodePrometheusMetricsResponse buildResponse(ClusterHealthResponse clusterHealth,
                                                               NodesStatsResponse nodesStats,
-                                                              @Nullable IndicesStatsResponse indicesStats) {
+                                                              @Nullable IndicesStatsResponse indicesStats,
+                                                              @Nullable ClusterStateResponse clusterStateResponse) {
             NodePrometheusMetricsResponse response = new NodePrometheusMetricsResponse(clusterHealth,
-                    nodesStats.getNodes().get(0), indicesStats);
+                    nodesStats.getNodes().get(0), indicesStats, clusterStateResponse,
+                    settings, clusterSettings);
             if (logger.isTraceEnabled()) {
                 logger.trace("Return response: [{}]", response);
             }

--- a/src/main/java/org/elasticsearch/plugin/prometheus/PrometheusExporterPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/prometheus/PrometheusExporterPlugin.java
@@ -66,6 +66,7 @@ public class PrometheusExporterPlugin extends Plugin implements ActionPlugin {
     @Override
     public List<Setting<?>> getSettings() {
         return Arrays.asList(
+                PrometheusMetricsCollector.PROMETHEUS_CLUSTER_SETTINGS,
                 PrometheusMetricsCollector.PROMETHEUS_INDICES
         );
     }

--- a/src/main/java/org/elasticsearch/rest/prometheus/RestPrometheusMetricsAction.java
+++ b/src/main/java/org/elasticsearch/rest/prometheus/RestPrometheusMetricsAction.java
@@ -74,7 +74,8 @@ public class RestPrometheusMetricsAction extends BaseRestHandler {
                 PrometheusMetricsCatalog catalog = new PrometheusMetricsCatalog(clusterName, nodeName, nodeId, "es_");
                 PrometheusMetricsCollector collector = new PrometheusMetricsCollector(settings, catalog);
                 collector.registerMetrics();
-                collector.updateMetrics(response.getClusterHealth(), response.getNodeStats(), response.getIndicesStats());
+                collector.updateMetrics(response.getClusterHealth(), response.getNodeStats(), response.getIndicesStats(),
+                        response.getClusterStatsData());
                 return new BytesRestResponse(RestStatus.OK, collector.getCatalog().toTextFormat());
             }
         });

--- a/src/test/resources/rest-api-spec/test/resthandler/40_10_cluster_settings_disk_threshold.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/40_10_cluster_settings_disk_threshold.yml
@@ -1,0 +1,189 @@
+---
+"Cluster settings statistics: disk threshold":
+
+  # -----------------------------------
+  # By default cluster.routing.allocation.disk.threshold_enabled is set to true.
+  # https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html
+  # OOTB there are no transient or persistent settings in the cluster:
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {persistent: {}}
+  - match: {transient: {}}
+
+  # "Disk allocation threshold" is enabled (by default)
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        es_cluster_routing_allocation_disk_threshold_enabled\{
+            cluster="PrometheusExporterITCluster"
+        \,} \s 1\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # Disable the "Disk allocation threshold" at the PERSISTENT level:
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            cluster.routing.allocation.disk.threshold_enabled: false
+        flat_settings: true
+
+  - match: {persistent: {cluster.routing.allocation.disk.threshold_enabled: "false"}}
+
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {transient: {}}
+  - match: {persistent: {cluster.routing.allocation.disk.threshold_enabled: "false"}}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        es_cluster_routing_allocation_disk_threshold_enabled\{
+            cluster="PrometheusExporterITCluster"
+        \,} \s 0\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # Enable the "Disk allocation threshold" at the TRANSIENT level:
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            cluster.routing.allocation.disk.threshold_enabled: true
+        flat_settings: true
+
+  - match: {transient: {cluster.routing.allocation.disk.threshold_enabled: "true"}}
+
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {transient: {cluster.routing.allocation.disk.threshold_enabled: "true"}}
+  - match: {persistent: {cluster.routing.allocation.disk.threshold_enabled: "false"}}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        es_cluster_routing_allocation_disk_threshold_enabled\{
+            cluster="PrometheusExporterITCluster"
+        \,} \s 1\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # Wipe out the "Disk allocation threshold" setting at the PERSISTENT level.
+  # There is still override at the TRANSIENT (ie. higher) level:
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            cluster.routing.allocation.disk.threshold_enabled: null
+        flat_settings: true
+
+  - match: {persistent: {}}
+
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {transient: {cluster.routing.allocation.disk.threshold_enabled: "true"}}
+  - match: {persistent: {}}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        es_cluster_routing_allocation_disk_threshold_enabled\{
+            cluster="PrometheusExporterITCluster"
+        \,} \s 1\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # Change the "Disk allocation threshold" setting at the TRANSIENT level:
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            cluster.routing.allocation.disk.threshold_enabled: null
+        flat_settings: true
+
+  - match: {persistent: {}}
+
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {transient: {cluster.routing.allocation.disk.threshold_enabled: "true"}}
+  - match: {persistent: {}}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        es_cluster_routing_allocation_disk_threshold_enabled\{
+            cluster="PrometheusExporterITCluster"
+        \,} \s 1\.0 \n?
+        .*/
+
+  # -----------------------------------
+  # Finally, wipe out the "Disk allocation threshold" setting from the TRANSIENT level:
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            cluster.routing.allocation.disk.threshold_enabled: null
+        flat_settings: true
+
+  - match: {transient: {}}
+
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {transient: {}}
+  - match: {persistent: {}}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
+        es_cluster_routing_allocation_disk_threshold_enabled\{
+            cluster="PrometheusExporterITCluster"
+        \,} \s 1\.0 \n?
+        .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/40_20_cluster_settings_disk_watermark_bytes.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/40_20_cluster_settings_disk_watermark_bytes.yml
@@ -1,0 +1,168 @@
+---
+"Cluster settings statistics: watermark":
+
+  # -----------------------------------
+  # By default cluster.routing.allocation.disk.watermark.* are set according to:
+  # https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html
+  # ---
+  # However, the REST test framework sets these settings in ClusterFormationTasks.groovy to '1b'.
+  # Or see buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+  # Things seems to be still moving in Elasticsearch...
+  - do:
+      cluster.get_settings:
+        include_defaults: true
+
+  - match: {persistent: {}}
+  - match: {transient: {}}
+  - match: {defaults.cluster.routing.allocation.disk.watermark.low: "1b"}
+  - match: {defaults.cluster.routing.allocation.disk.watermark.high: "1b"}
+  - match: {defaults.cluster.routing.allocation.disk.watermark.flood_stage: "1b"}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_low_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_low_bytes \s gauge \n
+        es_cluster_routing_allocation_disk_watermark_low_bytes\{
+            cluster="PrometheusExporterITCluster"
+        \,} \s 1\.0 \n?
+        .*/
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_high_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_high_bytes \s gauge \n
+        es_cluster_routing_allocation_disk_watermark_high_bytes\{
+            cluster="PrometheusExporterITCluster"
+        \,} \s 1\.0 \n?
+        .*/
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_flood_stage_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_flood_stage_bytes \s gauge \n
+        es_cluster_routing_allocation_disk_watermark_flood_stage_bytes\{
+            cluster="PrometheusExporterITCluster"
+        \,} \s 1\.0 \n?
+        .*/
+
+  # At the same time all pct alternatives do not report any metric values but they are still present.
+  # This is recommended, see https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics
+  #
+  # The following regexp-s work as follows:
+  # After the metric HELP and TYPE is found then only one the following two options is expected:
+  #   a) another "# HELP/TYPE" pattern is found because other metric is following right away
+  #   b) "<EOF>" This is the case we are in the end of the report
+  # Anything else is a bug.
+  #
+  # (tip: test regex online at https://regexr.com/)
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_low_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_low_pct \s gauge
+        (\n \# \s (HELP|TYPE).* | \s*)
+        /
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_high_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_high_pct \s gauge
+        (\n \# \s (HELP|TYPE).* | \s*)
+        /
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_flood_stage_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_flood_stage_pct \s gauge
+        (\n \# \s (HELP|TYPE).* | \s*)
+        /
+
+  # -----------------------------------
+  # Switch to pct based watermark values:
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            cluster.routing.allocation.disk.watermark.low: "99.9%"
+            cluster.routing.allocation.disk.watermark.high: "99.9%"
+            cluster.routing.allocation.disk.watermark.flood_stage: "99.9%"
+        flat_settings: true
+
+  - do:
+      cluster.get_settings:
+        include_defaults: true
+
+  - match: {transient: {}}
+  - match: {persistent.cluster.routing.allocation.disk.watermark.low: "99.9%"}
+  - match: {persistent.cluster.routing.allocation.disk.watermark.high: "99.9%"}
+  - match: {persistent.cluster.routing.allocation.disk.watermark.flood_stage: "99.9%"}
+
+  # Verify in Prometheus metrics:
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_low_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_low_pct \s gauge \n
+        es_cluster_routing_allocation_disk_watermark_low_pct\{
+            cluster="PrometheusExporterITCluster"
+        \,} \s 99\.9 \n?
+        .*/
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_high_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_high_pct \s gauge \n
+        es_cluster_routing_allocation_disk_watermark_high_pct\{
+            cluster="PrometheusExporterITCluster"
+        \,} \s 99\.9 \n?
+        .*/
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_flood_stage_pct (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_flood_stage_pct \s gauge \n
+        es_cluster_routing_allocation_disk_watermark_flood_stage_pct\{
+            cluster="PrometheusExporterITCluster"
+        \,} \s 99\.9 \n?
+        .*/
+
+  # At the same time all bytes alternatives do not report any metric values but they are still present.
+  # This is recommended, see https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_low_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_low_bytes \s gauge
+        (\n \# \s (HELP|TYPE).* | \s*)
+        /
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_high_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_high_bytes \s gauge
+        (\n \# \s (HELP|TYPE).* | \s*)
+        /
+
+  - match:
+      $body: |
+        /.*
+        \# \s HELP \s es_cluster_routing_allocation_disk_watermark_flood_stage_bytes (\s|\w|\d)+ \n
+        \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_flood_stage_bytes \s gauge
+        (\n \# \s (HELP|TYPE).* | \s*)
+        /


### PR DESCRIPTION
Closes #124

Exposing new metrics based on the following ES cluster settings:

- `cluster.routing.allocation.disk.threshold_enabled`
- `cluster.routing.allocation.disk.watermark.[low|high|flood_stage]`

Metrics like this are useful in alerting (and predicting) when shard allocation logic changes in Elasticsearch cluster. Admins should be aware of the fact that ES is stopping allocating new shards to nodes, or worse, if shards are being re-allocated to different nodes.

However, **there is a tricky part**. There settings can be changed dynamically by user and they can be set in two different formats (percents and bytes values). In order to make it easier for Prometheus to consume these metrics I created **two** versions for each settings, one for percent value, second for bytes value. Only one of them is populated with a value when scraped by Prometheus. However, both metric formats for each metric are still present (yet only one should be populated at any given point in time). This should be in sync with recommended practice to [avoid missing metrics](https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics).

It is then up to Prometheus query and Alerting rules language to correctly use and apply these values. Obviously, it should be taken into account only when `cluster.routing.allocation.disk.threshold_enabled` is set to `true` (which is the default).

This commit adds the following Prometheus metrics:

- `cluster_routing_allocation_disk_threshold_enabled`
- `cluster_routing_allocation_disk_watermark_low_bytes`
- `cluster_routing_allocation_disk_watermark_high_bytes`
- `cluster_routing_allocation_disk_watermark_flood_stage_bytes`
- `cluster_routing_allocation_disk_watermark_low_pct`
- `cluster_routing_allocation_disk_watermark_high_pct`
- `cluster_routing_allocation_disk_watermark_flood_stage_pct`

All of them can be disabled by setting `prometheus.cluster.settings: false` in `elasticsearch.yml`.