### PR TITLE
Release v6.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
+| 6.7.0          | 6.7.0.0        | Apr 02, 2019 |
 | 6.6.2          | 6.6.2.0        | Mar 14, 2019 |
 | 6.6.1          | 6.6.1.0        | Feb 21, 2019 |
 | 6.6.0          | 6.6.0.0        | Feb 11, 2019 |
@@ -113,7 +114,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
 ## Install
 
 - Since Elasticsearch 6.0.0 :
-    `./bin/elasticsearch-plugin install -b https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-6.6.2.0.zip`
+    `./bin/elasticsearch-plugin install -b https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-6.7.0.0.zip`
 
 - On Elasticsearch 5.x.x :
     `./bin/elasticsearch-plugin install -b https://distfiles.compuscene.net/elasticsearch/elasticsearch-prometheus-exporter-5.6.14.0.zip`

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.elasticsearch.gradle:build-tools:6.6.2" // How can we use ${versions.elasticsearch} here ???
+        classpath "org.elasticsearch.gradle:build-tools:6.7.0" // How can we use ${versions.elasticsearch} here ???
         classpath group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.0'
         classpath group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0'
         classpath group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.0'
@@ -47,9 +47,11 @@ thirdPartyAudit.enabled = false
 // license header checks can be disabled
 licenseHeaders.enabled = true
 
+// No unit tests in this plugin
+unitTest.enabled = false
+
 // There are only integration tests
 integTestRunner.enabled = true
-test.enabled = false
 
 println "Host: " + java.net.InetAddress.getLocalHost()
 println "Gradle: " + gradle.gradleVersion + " JVM: " + org.gradle.internal.jvm.Jvm.current() + " Groovy: " + GroovySystem.getVersion()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.elasticsearch.plugin.prometheus
 
-version = 6.6.2.1-SNAPSHOT
+version = 6.7.0.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.elasticsearch.plugin.prometheus.PrometheusExporterPlugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.elasticsearch.plugin.prometheus
 
-version = 6.7.0.0
+version = 6.7.0.1-SNAPSHOT
 
 pluginName = prometheus-exporter
 pluginClassname = org.elasticsearch.plugin.prometheus.PrometheusExporterPlugin

--- a/src/main/java/org/elasticsearch/action/ClusterStatsData.java
+++ b/src/main/java/org/elasticsearch/action/ClusterStatsData.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
+import org.elasticsearch.common.unit.RatioValue;
 
 import java.io.IOException;
 
@@ -109,7 +110,7 @@ public class ClusterStatsData extends ActionResponse {
         String value = s.get(key);
         if (value != null && pctPointer[0] == null) {
             try {
-                pctPointer[0] = s.getAsRatio(key, null).getAsPercent();
+                pctPointer[0] = RatioValue.parseRatioValue(s.get(key, null)).getAsPercent();
             } catch (SettingsException | ElasticsearchParseException | NullPointerException e1) {
                 if (bytesPointer[0] == null) {
                     try {


### PR DESCRIPTION
Closes #173

There were two small changes I had to do:

First, I had to make a direct use of static `RatioValue.parseRatioValue` method due to this refactoring:
https://github.com/elastic/elasticsearch/commit/21a88d5505835592dcaea1e56690c94c723daa4e#diff-e91e66b1747cca0f983474fdd0747b61L390

Second, I had to explicitly turn off unitTests to avoid error like this:
```
> Task :testingConventions FAILED
Seem like test classes but don't match naming convention:
  * org.elasticsearch.DummyTest
Expected at least one test class included in task :unitTest, but found none.
```
Just to make it clear, turning off unitTests means that all integration tests are still running and required to pass. However, this setting is now needed as long as we do not have any real unit tests java classes (and we do not have any atm).

@vvanholl Please notice that the release commit is already attached the release [tag `6.7.0.0`](https://github.com/vvanholl/elasticsearch-prometheus-exporter/tree/6.7.0.0). In other words if merge goes smoothy (no changes in commit hashes) then no need to create the tag again.