### PR TITLE
Exclude metrics based on prefix(es)

### DIFF
--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCatalog.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCatalog.java
@@ -17,7 +17,6 @@
 
 package org.compuscene.metrics.prometheus;
 
-import io.prometheus.client.Collector;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.rest.prometheus.RestPrometheusMetricsAction;
@@ -28,7 +27,6 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
@@ -51,7 +49,12 @@ public class PrometheusMetricsCatalog {
     private CollectorRegistry registry;
     private List<String> excludePrefixes;
 
-    public PrometheusMetricsCatalog(String clusterName, String nodeName, String nodeId, String metricPrefix, List<String> excludePrefixes) {
+    public PrometheusMetricsCatalog(
+            String clusterName,
+            String nodeName,
+            String nodeId,
+            String metricPrefix,
+            List<String> excludePrefixes) {
         this.clusterName = clusterName;
         this.nodeName = nodeName;
         this.nodeId = nodeId;

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
@@ -21,6 +21,13 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import static java.util.Collections.emptyList;
+
 /**
  * A container to keep settings for prometheus up to date with cluster setting changes.
  *
@@ -40,15 +47,21 @@ public class PrometheusSettings {
     public static final Setting<Boolean> PROMETHEUS_INDICES =
             Setting.boolSetting("prometheus.indices", true,
                     Setting.Property.Dynamic, Setting.Property.NodeScope);
+    public static final Setting<List<String>> PROMETHEUS_EXCLUDE =
+            Setting.listSetting("prometheus.exclude", emptyList(),
+                    Function.identity(), Setting.Property.Dynamic, Setting.Property.NodeScope);
 
     private volatile boolean clusterSettings;
     private volatile boolean indices;
+    private volatile List<String> exclude;
 
     public PrometheusSettings(Settings settings, ClusterSettings clusterSettings) {
         setPrometheusClusterSettings(PROMETHEUS_CLUSTER_SETTINGS.get(settings));
         setPrometheusIndices(PROMETHEUS_INDICES.get(settings));
+        setPrometheusExclude(PROMETHEUS_EXCLUDE.get(settings));
         clusterSettings.addSettingsUpdateConsumer(PROMETHEUS_CLUSTER_SETTINGS, this::setPrometheusClusterSettings);
         clusterSettings.addSettingsUpdateConsumer(PROMETHEUS_INDICES, this::setPrometheusIndices);
+        clusterSettings.addSettingsUpdateConsumer(PROMETHEUS_EXCLUDE, this::setPrometheusExclude);
     }
 
     private void setPrometheusClusterSettings(boolean flag) {
@@ -59,11 +72,19 @@ public class PrometheusSettings {
         this.indices = flag;
     }
 
+    private void setPrometheusExclude(List<String> excludes) {
+        this.exclude = excludes;
+    }
+
     public boolean getPrometheusClusterSettings() {
         return this.clusterSettings;
     }
 
     public boolean getPrometheusIndices() {
         return this.indices;
+    }
+
+    public List<String> getPrometheusExclude() {
+        return this.exclude;
     }
 }

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusSettings.java
@@ -17,16 +17,14 @@
 
 package org.compuscene.metrics.prometheus;
 
+import static java.util.Collections.emptyList;
+
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
-
-import static java.util.Collections.emptyList;
 
 /**
  * A container to keep settings for prometheus up to date with cluster setting changes.

--- a/src/main/java/org/elasticsearch/plugin/prometheus/PrometheusExporterPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/prometheus/PrometheusExporterPlugin.java
@@ -71,7 +71,8 @@ public class PrometheusExporterPlugin extends Plugin implements ActionPlugin {
     public List<Setting<?>> getSettings() {
         List<Setting<?>> settings = Arrays.asList(
                 PrometheusSettings.PROMETHEUS_CLUSTER_SETTINGS,
-                PrometheusSettings.PROMETHEUS_INDICES
+                PrometheusSettings.PROMETHEUS_INDICES,
+                PrometheusSettings.PROMETHEUS_EXCLUDE
         );
         return Collections.unmodifiableList(settings);
     }

--- a/src/main/java/org/elasticsearch/rest/prometheus/RestPrometheusMetricsAction.java
+++ b/src/main/java/org/elasticsearch/rest/prometheus/RestPrometheusMetricsAction.java
@@ -76,7 +76,7 @@ public class RestPrometheusMetricsAction extends BaseRestHandler {
                     logger.trace("Prepare new Prometheus metric collector for: [{}], [{}], [{}]", clusterName, nodeId,
                             nodeName);
                 }
-                PrometheusMetricsCatalog catalog = new PrometheusMetricsCatalog(clusterName, nodeName, nodeId, "es_");
+                PrometheusMetricsCatalog catalog = new PrometheusMetricsCatalog(clusterName, nodeName, nodeId, "es_", prometheusSettings.getPrometheusExclude());
                 PrometheusMetricsCollector collector = new PrometheusMetricsCollector(
                         catalog,
                         prometheusSettings.getPrometheusIndices(),

--- a/src/main/java/org/elasticsearch/rest/prometheus/RestPrometheusMetricsAction.java
+++ b/src/main/java/org/elasticsearch/rest/prometheus/RestPrometheusMetricsAction.java
@@ -76,7 +76,12 @@ public class RestPrometheusMetricsAction extends BaseRestHandler {
                     logger.trace("Prepare new Prometheus metric collector for: [{}], [{}], [{}]", clusterName, nodeId,
                             nodeName);
                 }
-                PrometheusMetricsCatalog catalog = new PrometheusMetricsCatalog(clusterName, nodeName, nodeId, "es_", prometheusSettings.getPrometheusExclude());
+                PrometheusMetricsCatalog catalog = new PrometheusMetricsCatalog(
+                        clusterName,
+                        nodeName,
+                        nodeId,
+                        "es_",
+                        prometheusSettings.getPrometheusExclude());
                 PrometheusMetricsCollector collector = new PrometheusMetricsCollector(
                         catalog,
                         prometheusSettings.getPrometheusIndices(),

--- a/src/test/resources/rest-api-spec/test/resthandler/20_12_index_level_metrics_excluded.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/20_12_index_level_metrics_excluded.yml
@@ -1,0 +1,106 @@
+# Test that excluding some metrics dynamically causes
+# those metrics to not be exposed.
+---
+"Dynamically exclude some metrics":
+
+  # Assume we have no indices in the cluster
+  - do:
+      cluster.stats: {}
+
+  - match: { indices.count: 0 }
+
+
+  # twitter index should not be present in the prometheus stats
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: /.*.*/
+
+  # Create twitter index
+  - do:
+      index:
+        index:  twitter
+        type:   foo
+        id:     1
+        body:   { foo: bar }
+
+  - do:
+      indices.refresh: { allow_no_indices: true }
+
+  - do:
+      cluster.stats: {}
+
+  - match: { indices.count: 1 }
+
+  # Now the twitter index details are present
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: /.*[t][w][i][t][t][e][r].*/
+
+  # Let's start with just the default OOTB settings, this means
+  # both the persistent and transient settings levels are empty.
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {persistent: {}}
+  - match: {transient: {}}
+
+  # -----------------------------------
+  # Exclude "index_search" via "prometheus.exclude" at the TRANSIENT level:
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            prometheus:
+              exclude: ["index_search"]
+        flat_settings: true
+
+  - match: {transient: {prometheus.exclude: ["index_search"]}}
+
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {transient: {prometheus.exclude: ["index_search"]}}
+  - match: {persistent: {}}
+
+  # Verify excluded "index_search" metrics are not exported now.
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: /.*[^i][^n][^d][^e][^x][^_][^s][^e][^a][^r][^c][^h].*/
+
+  # -----------------------------------
+  # Clear the "prometheus.exclude" settings:
+  - do:
+      cluster.put_settings:
+        body:
+          transient:
+            prometheus:
+              exclude: null
+        flat_settings: true
+
+  # And we should see the twitter index details back in prometheus metrics
+  - do:
+      prometheus.metrics: {}
+
+  - match:
+      $body: /.*index_search.*/
+
+  # -----------------------------------
+  # Test clean up...
+  - do:
+      indices.delete:
+        index: twitter
+
+  - do:
+      cluster.get_settings:
+        flat_settings: true
+
+  - match: {persistent: {}}
+  - match: {transient: {}}


### PR DESCRIPTION
Forgive me if this is terrible, I haven't written Java in about 5 years and it was only for classwork prior to this.

**Context**

This plugin is fantastic with the amount of detail it provides, especially per index. The only problem we have is with some of our heavier clusters we still want to collect a few of the index level metrics. Exposing all of the metrics isn't doable as each node would give off ~25MB of metrics or 202k individual metrics _each_.

So I went through and added a setting to exclude metrics based on a prefix(es).