### PR TITLE
Fix for ES 7.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
+| 7.3.0          | 7.3.0.0        | Aug 13, 2019 |
 | 7.2.1          | 7.2.0.0        | Jul 31, 2019 |
 | 7.2.0          | 7.2.0.0        | Jul 12, 2019 |
 | 7.1.1          | 7.1.1.0        | May 31, 2019 |
@@ -130,7 +131,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
 ## Install
 
 - Since Elasticsearch 7.0.0 :
-    `./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/7.2.1.0/prometheus-exporter-7.2.1.0.zip`
+    `./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/7.3.0.0/prometheus-exporter-7.3.0.0.zip`
 
 - Since Elasticsearch 6.0.0 :
     `./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/6.8.0.0/prometheus-exporter-6.8.0.0.zip`

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.elasticsearch.gradle:build-tools:7.2.1" // How can we use ${versions.elasticsearch} here ???
+        classpath "org.elasticsearch.gradle:build-tools:7.3.0" // How can we use ${versions.elasticsearch} here ???
         classpath group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.0'
         classpath group: 'com.sun.xml.bind', name: 'jaxb-core', version: '2.3.0'
         classpath group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,14 @@ configurations {
     }
 }
 
+// Fix for https://github.com/elastic/elasticsearch/issues/45073
+// TODO(lukas-vlcek): Should be removed for ES v7.3.1 and later.
+configurations.all {
+  resolutionStrategy.dependencySubstitution {
+    substitute project(':rest-api-spec') with module ("org.elasticsearch:rest-api-spec:${versions.elasticsearch}")
+  }
+}
+
 dependencies {
     compile "org.elasticsearch:elasticsearch:${versions.elasticsearch}"
     compile "io.prometheus:simpleclient:${versions.prometheus}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.elasticsearch.plugin.prometheus
 
-version = 7.2.1.0
+version = 7.3.0.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.elasticsearch.plugin.prometheus.PrometheusExporterPlugin

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
 rootProject.name = "prometheus-exporter"
+
+// Fix for https://github.com/elastic/elasticsearch/issues/45073
+// TODO(lukas-vlcek): Should be removed for ES v7.3.1 and later.
+include ':rest-api-spec'

--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -24,7 +24,7 @@ import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.cluster.health.ClusterIndexHealth;
-import org.elasticsearch.cluster.node.DiscoveryNode.Role;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.http.HttpStats;
 import org.elasticsearch.indices.NodeIndicesStats;
 import org.elasticsearch.indices.breaker.AllCircuitBreakerStats;
@@ -129,14 +129,17 @@ public class PrometheusMetricsCollector {
 
     private void updateNodeMetrics(NodeStats ns) {
         if (ns != null) {
+
+            // Plugins can introduce custom node roles from 7.3.0: https://github.com/elastic/elasticsearch/pull/43175
+            // TODO(lukas-vlcek): List of node roles can not be static but needs to be created dynamically.
             Map<String, Integer> roles = new HashMap<>();
 
             roles.put("master", 0);
             roles.put("data", 0);
             roles.put("ingest", 0);
 
-            for (Role r : ns.getNode().getRoles()) {
-                roles.put(r.getRoleName(), 1);
+            for (DiscoveryNodeRole r : ns.getNode().getRoles()) {
+                roles.put(r.roleName(), 1);
             }
 
             for (String k : roles.keySet()) {

--- a/src/main/java/org/elasticsearch/action/NodePrometheusMetricsAction.java
+++ b/src/main/java/org/elasticsearch/action/NodePrometheusMetricsAction.java
@@ -21,18 +21,16 @@ import org.elasticsearch.common.io.stream.Writeable;
 /**
  * Action class for Prometheus Exporter plugin.
  */
-public class NodePrometheusMetricsAction extends Action<NodePrometheusMetricsResponse> {
+public class NodePrometheusMetricsAction extends ActionType<NodePrometheusMetricsResponse> {
+    // TODO(lukas-vlcek): There are ongoing changes for ActionType class. This code needs additional review.
+    // - https://github.com/elastic/elasticsearch/pull/43778
+    // - https://github.com/elastic/elasticsearch/commit/b33ffc1ae06035e934277f17c4b5d9851f607056#diff-80df90ca727aadbbe854902f81bda313
+    // - https://github.com/elastic/elasticsearch/commit/5a9f81791a1be7fe6dd97728384ebafb189ab211#diff-80df90ca727aadbbe854902f81bda313
     public static final NodePrometheusMetricsAction INSTANCE = new NodePrometheusMetricsAction();
     public static final String NAME = "cluster:monitor/prometheus/metrics";
 
     private NodePrometheusMetricsAction() {
-        super(NAME);
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public NodePrometheusMetricsResponse newResponse() {
-        throw new UnsupportedOperationException("usage of Streamable is to be replaced by Writeable");
+        super(NAME, null);
     }
 
     @Override


### PR DESCRIPTION
Do not merge. This is WIP.

This branch fixes the main code changes done in Elasticsearch 7.3.0 plus some temp workaround for broken gradle build. It is based on https://github.com/vvanholl/elasticsearch-prometheus-exporter/pull/206

This is to demonstrate that we know how to fix things. But it still needs more work. I left some `[TODO]`s in the code. We also need to reorder commits. As of writing the (original) commit that changes the version of the plugin to 7.3.0 is not the latest one, hence it shouldn't be merged at this moment.

//cc FYI @foxdalas 