### PR TITLE
Basic work for 7.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.elasticsearch.plugin.prometheus
 
-version = 7.3.2.1-SNAPSHOT
+version = 7.5.0.0-SNAPSHOT
 
 pluginName = prometheus-exporter
 pluginClassname = org.elasticsearch.plugin.prometheus.PrometheusExporterPlugin

--- a/src/main/java/org/elasticsearch/action/ClusterStatsData.java
+++ b/src/main/java/org/elasticsearch/action/ClusterStatsData.java
@@ -125,9 +125,7 @@ public class ClusterStatsData extends ActionResponse {
         }
     }
 
-    @Override
     public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
         thresholdEnabled = in.readOptionalBoolean();
         //
         diskLowInBytes = in.readOptionalLong();
@@ -141,7 +139,6 @@ public class ClusterStatsData extends ActionResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
         out.writeOptionalBoolean(thresholdEnabled);
         //
         out.writeOptionalLong(diskLowInBytes);

--- a/src/main/java/org/elasticsearch/action/NodePrometheusMetricsRequest.java
+++ b/src/main/java/org/elasticsearch/action/NodePrometheusMetricsRequest.java
@@ -18,11 +18,18 @@
 package org.elasticsearch.action;
 
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
 
 /**
  * Action request class for Prometheus Exporter plugin.
  */
 public class NodePrometheusMetricsRequest extends MasterNodeReadRequest<NodePrometheusMetricsRequest> {
+    public NodePrometheusMetricsRequest(StreamInput streamInput) {
+    }
+
+    public NodePrometheusMetricsRequest() {
+    }
+
     @Override
     public ActionRequestValidationException validate() {
         return null;

--- a/src/main/java/org/elasticsearch/action/NodePrometheusMetricsResponse.java
+++ b/src/main/java/org/elasticsearch/action/NodePrometheusMetricsResponse.java
@@ -43,12 +43,10 @@ public class NodePrometheusMetricsResponse extends ActionResponse {
     private ClusterStatsData clusterStatsData = null;
 
     public NodePrometheusMetricsResponse(StreamInput in) throws IOException {
-        super.readFrom(in);
         clusterHealth = ClusterHealthResponse.readResponseFrom(in);
-        nodeStats = NodeStats.readNodeStats(in);
-        BroadcastResponse br = new BroadcastResponse();
-        br.readFrom(in);
-        ShardStats[] ss = in.readArray(ShardStats::readShardStats, (size) -> new ShardStats[size]);
+        nodeStats = new NodeStats(in);
+        BroadcastResponse br = new BroadcastResponse(in);
+        ShardStats[] ss = in.readArray(ShardStats::new, (size) -> new ShardStats[size]);
         indicesStats = PackageAccessHelper.createIndicesStatsResponse(
                 ss, br.getTotalShards(), br.getSuccessfulShards(), br.getFailedShards(),
                 Arrays.asList(br.getShardFailures())
@@ -89,7 +87,6 @@ public class NodePrometheusMetricsResponse extends ActionResponse {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
         clusterHealth.writeTo(out);
         nodeStats.writeTo(out);
         if (indicesStats != null) {

--- a/src/main/java/org/elasticsearch/action/TransportNodePrometheusMetricsAction.java
+++ b/src/main/java/org/elasticsearch/action/TransportNodePrometheusMetricsAction.java
@@ -59,8 +59,7 @@ public class TransportNodePrometheusMetricsAction extends HandledTransportAction
     public TransportNodePrometheusMetricsAction(Settings settings, Client client,
                                                 TransportService transportService, ActionFilters actionFilters,
                                                 ClusterSettings clusterSettings) {
-        super(NodePrometheusMetricsAction.NAME, transportService, actionFilters,
-                NodePrometheusMetricsRequest::new);
+        super(NodePrometheusMetricsAction.NAME, transportService, actionFilters, NodePrometheusMetricsRequest::new);
         this.client = client;
         this.settings = settings;
         this.clusterSettings = clusterSettings;

--- a/src/main/java/org/elasticsearch/rest/prometheus/RestPrometheusMetricsAction.java
+++ b/src/main/java/org/elasticsearch/rest/prometheus/RestPrometheusMetricsAction.java
@@ -47,7 +47,6 @@ public class RestPrometheusMetricsAction extends BaseRestHandler {
 
     @Inject
     public RestPrometheusMetricsAction(Settings settings, ClusterSettings clusterSettings, RestController controller) {
-        super(settings);
         this.prometheusSettings = new PrometheusSettings(settings, clusterSettings);
         controller.registerHandler(GET, "/_prometheus/metrics", this);
     }


### PR DESCRIPTION
No clue how valid this is, but this appears to work. Looks like most of the APIs for 7.3.2. to 7.4 were no-ops anyway, just removed those.

Wasn't able to run the integration tests as the maven repo for them is only up to 7.4.2 (https://mvnrepository.com/artifact/org.elasticsearch/elasticsearch).

Did manage to install it locally in a 7.5.0 container, everything appears fine. Stats update appropriately from what I can tell.