### PR TITLE
Upgrade to ES 7.5.0 and release 7.5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
+| 7.5.0          | 7.5.0.0        | Jan 16, 2020 |
 | 7.4.2          | 7.4.2.0        | Jan 13, 2020 |
 | 7.4.1          | 7.4.1.0        | Jan 13, 2020 |
 | 7.4.0          | 7.4.0.0        | Jan 07, 2020 |
@@ -142,7 +143,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
 ## Install
 
 - Since Elasticsearch 7.0.0 :
-    `./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/7.4.2.0/prometheus-exporter-7.4.2.0.zip`
+    `./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/7.5.0.0/prometheus-exporter-7.5.0.0.zip`
 
 - Since Elasticsearch 6.0.0 :
     `./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/6.8.0.0/prometheus-exporter-6.8.0.0.zip`

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,11 @@
 import com.github.mgk.gradle.*
 
+// ------ TODO(lukas-vlcek): Hack should be removed when possible ------
+// See https://github.com/elastic/elasticsearch/issues/49787#issuecomment-567397768
+import org.elasticsearch.gradle.testclusters.TestClustersRegistry
+import org.elasticsearch.gradle.testclusters.TestClustersPlugin
+// ------
+
 buildscript {
     ext {
         es_version = version.replaceAll(/\.[0-9]+(|-SNAPSHOT)$/, "")
@@ -29,6 +35,16 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'elasticsearch.esplugin'
+
+// ------ TODO(lukas-vlcek): Hack needed for ES 7.5.0 release ------
+// Remove this before release 7.5.1
+// See https://github.com/elastic/elasticsearch/issues/49787#issuecomment-562704640
+configurations.whenObjectAdded { c ->
+    if (c.name == 'elasticsearch_7.5.0_integ_test_zip_null') {
+        project.dependencies.add('elasticsearch_7.5.0_integ_test_zip_null', 'org.elasticsearch.distribution.integ-test-zip:elasticsearch:7.5.0@zip')
+    }
+}
+// ------
 
 // Uncomment if you want to use: System.out.println("Emergency!");
 // Logs are found in build/cluster/integTestCluster*/cwd/run.log
@@ -105,9 +121,19 @@ esplugin {
     classname pluginClassname
 }
 
-integTestCluster {
-    numNodes = 2
-    clusterName = "PrometheusExporterITCluster"
+testClusters.integTest {
+    numberOfNodes = 2
+// There does not seem to be any easy way how to setup custom cluster name.
+
+//    This worked in ES 7.4.x, but now results in:
+//    A problem occurred evaluating root project 'prometheus-exporter'.
+//    > Cannot set the property 'clusterName' because the backing field is final.
+//    clusterName = "PrometheusExporterITCluster"
+
+//    This does not work in ES 7.5.x too:
+//    Execution failed for task ':integTestRunner'.
+//    > Testclusters does not allow the following settings to be changed:[cluster.name] for node{::integTest-0}
+//    setting 'cluster.name', 'PrometheusExporterITCluster'
 }
 
 checkstyle {
@@ -154,3 +180,11 @@ task release() {
         dependsOn(["githubRelease"])
     }
 }
+
+// ------ TODO(lukas-vlcek): Hack should be removed when possible ------
+// See https://github.com/elastic/elasticsearch/issues/49787#issuecomment-567397768
+TestClustersRegistry registry = project.rootProject.extensions.create("testClustersRegistry", TestClustersRegistry)
+TestClustersPlugin.configureClaimClustersHook(project.gradle, registry)
+TestClustersPlugin.configureStartClustersHook(project.gradle, registry)
+TestClustersPlugin.configureStopClustersHook(project.gradle, registry)
+// ------

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.elasticsearch.plugin.prometheus
 
-version = 7.4.2.1-SNAPSHOT
+version = 7.5.0.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.elasticsearch.plugin.prometheus.PrometheusExporterPlugin

--- a/src/main/java/org/elasticsearch/action/admin/indices/stats/PackageAccessHelper.java
+++ b/src/main/java/org/elasticsearch/action/admin/indices/stats/PackageAccessHelper.java
@@ -27,6 +27,9 @@ public class PackageAccessHelper {
 
     /**
      * Shortcut to IndicesStatsResponse constructor which has package access restriction.
+     * @param in StreamInput
+     * @return IndicesStatsResponse
+     * @throws IOException When something goes wrong
      */
     public static IndicesStatsResponse createIndicesStatsResponse(StreamInput in) throws IOException {
         return in.readOptionalWriteable(IndicesStatsResponse::new);

--- a/src/test/resources/rest-api-spec/test/resthandler/20_10_cluster_settings_metrics_disabled.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/20_10_cluster_settings_metrics_disabled.yml
@@ -24,7 +24,7 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
         es_cluster_routing_allocation_disk_threshold_enabled\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 1\.0 \n?
         .*/
 
@@ -153,6 +153,6 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
         es_cluster_routing_allocation_disk_threshold_enabled\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 1\.0 \n?
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_00_index_level_info.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_00_index_level_info.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_shards_number \s gauge \n
         (
           es_index_shards_number\{
-              cluster="PrometheusExporterITCluster",
+              cluster="integTest",
               type="(active_primary|initializing|relocating|shards|active|unassigned)",
               index="twitter"
           ,\} \s+ \d+\.\d+ \n?
@@ -47,7 +47,7 @@
         \# \s HELP \s es_index_status (\s|\w|\d)+ \n
         \# \s TYPE \s es_index_status \s gauge \n
         es_index_status\{
-            cluster="PrometheusExporterITCluster",index="twitter"
+            cluster="integTest",index="twitter"
         \,} \s \d+\.\d+ \n?
         .*/
 
@@ -57,7 +57,7 @@
         \# \s HELP \s es_index_replicas_number (\s|\w|\d)+ \n
         \# \s TYPE \s es_index_replicas_number \s gauge \n
         es_index_replicas_number\{
-            cluster="PrometheusExporterITCluster",index="twitter"
+            cluster="integTest",index="twitter"
         ,\} \s+ \d+\.\d+ \n?
         .*/
 
@@ -97,7 +97,7 @@
         \# \s TYPE \s es_index_doc_number \s gauge \n
         (
           es_index_doc_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -109,7 +109,7 @@
         \# \s TYPE \s es_index_doc_deleted_number \s gauge \n
         (
           es_index_doc_deleted_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -121,7 +121,7 @@
         \# \s TYPE \s es_index_store_size_bytes \s gauge \n
         (
           es_index_store_size_bytes\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_10_index_indexing.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_10_index_indexing.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_indexing_delete_count \s gauge \n
         (
           es_index_indexing_delete_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_indexing_delete_current_number \s gauge \n
         (
           es_index_indexing_delete_current_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -58,7 +58,7 @@
         \# \s TYPE \s es_index_indexing_delete_time_seconds \s gauge \n
         (
           es_index_indexing_delete_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -70,7 +70,7 @@
         \# \s TYPE \s es_index_indexing_index_count \s gauge \n
         (
           es_index_indexing_index_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -82,7 +82,7 @@
         \# \s TYPE \s es_index_indexing_index_current_number \s gauge \n
         (
           es_index_indexing_index_current_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -94,7 +94,7 @@
         \# \s TYPE \s es_index_indexing_index_failed_count \s gauge \n
         (
           es_index_indexing_index_failed_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -106,7 +106,7 @@
         \# \s TYPE \s es_index_indexing_index_time_seconds \s gauge \n
         (
           es_index_indexing_index_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -118,7 +118,7 @@
         \# \s TYPE \s es_index_indexing_noop_update_count \s gauge \n
         (
           es_index_indexing_noop_update_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -130,7 +130,7 @@
         \# \s TYPE \s es_index_indexing_is_throttled_bool \s gauge \n
         (
           es_index_indexing_is_throttled_bool\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -142,7 +142,7 @@
         \# \s TYPE \s es_index_indexing_throttle_time_seconds \s gauge \n
         (
           es_index_indexing_throttle_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_11_index_get.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_11_index_get.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_get_count \s gauge \n
         (
           es_index_get_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_get_time_seconds \s gauge \n
         (
           es_index_get_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -58,7 +58,7 @@
         \# \s TYPE \s es_index_get_exists_count \s gauge \n
         (
           es_index_get_exists_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -70,7 +70,7 @@
         \# \s TYPE \s es_index_get_exists_time_seconds \s gauge \n
         (
           es_index_get_exists_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -82,7 +82,7 @@
         \# \s TYPE \s es_index_get_missing_count \s gauge \n
         (
           es_index_get_missing_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -94,7 +94,7 @@
         \# \s TYPE \s es_index_get_missing_time_seconds \s gauge \n
         (
           es_index_get_missing_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -106,7 +106,7 @@
         \# \s TYPE \s es_index_get_current_number \s gauge \n
         (
           es_index_get_current_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_12_index_search.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_12_index_search.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_search_open_contexts_number \s gauge \n
         (
           es_index_search_open_contexts_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_search_fetch_count \s gauge \n
         (
           es_index_search_fetch_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -58,7 +58,7 @@
         \# \s TYPE \s es_index_search_fetch_current_number \s gauge \n
         (
           es_index_search_fetch_current_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -70,7 +70,7 @@
         \# \s TYPE \s es_index_search_fetch_time_seconds \s gauge \n
         (
           es_index_search_fetch_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -82,7 +82,7 @@
         \# \s TYPE \s es_index_search_query_count \s gauge \n
         (
           es_index_search_query_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -94,7 +94,7 @@
         \# \s TYPE \s es_index_search_query_current_number \s gauge \n
         (
           es_index_search_query_current_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -106,7 +106,7 @@
         \# \s TYPE \s es_index_search_query_time_seconds \s gauge \n
         (
           es_index_search_query_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -118,7 +118,7 @@
         \# \s TYPE \s es_index_search_scroll_count \s gauge \n
         (
           es_index_search_scroll_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -130,7 +130,7 @@
         \# \s TYPE \s es_index_search_scroll_current_number \s gauge \n
         (
           es_index_search_scroll_current_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -142,7 +142,7 @@
         \# \s TYPE \s es_index_search_scroll_time_seconds \s gauge \n
         (
           es_index_search_scroll_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_13_index_merges.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_13_index_merges.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_merges_current_number \s gauge \n
         (
           es_index_merges_current_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_merges_current_docs_number \s gauge \n
         (
           es_index_merges_current_docs_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -58,7 +58,7 @@
         \# \s TYPE \s es_index_merges_current_size_bytes \s gauge \n
         (
           es_index_merges_current_size_bytes\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -70,7 +70,7 @@
         \# \s TYPE \s es_index_merges_total_number \s gauge \n
         (
           es_index_merges_total_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -82,7 +82,7 @@
         \# \s TYPE \s es_index_merges_total_time_seconds \s gauge \n
         (
           es_index_merges_total_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -94,7 +94,7 @@
         \# \s TYPE \s es_index_merges_total_docs_count \s gauge \n
         (
           es_index_merges_total_docs_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -106,7 +106,7 @@
         \# \s TYPE \s es_index_merges_total_size_bytes \s gauge \n
         (
           es_index_merges_total_size_bytes\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -118,7 +118,7 @@
         \# \s TYPE \s es_index_merges_total_stopped_time_seconds \s gauge \n
         (
           es_index_merges_total_stopped_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -130,7 +130,7 @@
         \# \s TYPE \s es_index_merges_total_throttled_time_seconds \s gauge \n
         (
           es_index_merges_total_throttled_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -142,7 +142,7 @@
         \# \s TYPE \s es_index_merges_total_auto_throttle_bytes \s gauge \n
         (
           es_index_merges_total_auto_throttle_bytes\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+([eE]\d+)? \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_14_index_refresh.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_14_index_refresh.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_refresh_total_count \s gauge \n
         (
           es_index_refresh_total_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_refresh_total_time_seconds \s gauge \n
         (
           es_index_refresh_total_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -58,7 +58,7 @@
         \# \s TYPE \s es_index_refresh_listeners_number \s gauge \n
         (
           es_index_refresh_listeners_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_15_index_flush.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_15_index_flush.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_flush_total_count \s gauge \n
         (
           es_index_flush_total_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_flush_total_time_seconds \s gauge \n
         (
           es_index_flush_total_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_16_index_querycache.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_16_index_querycache.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_querycache_cache_count \s gauge \n
         (
           es_index_querycache_cache_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_querycache_cache_size_bytes \s gauge \n
         (
           es_index_querycache_cache_size_bytes\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -58,7 +58,7 @@
         \# \s TYPE \s es_index_querycache_evictions_count \s gauge \n
         (
           es_index_querycache_evictions_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -70,7 +70,7 @@
         \# \s TYPE \s es_index_querycache_hit_count \s gauge \n
         (
           es_index_querycache_hit_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -82,7 +82,7 @@
         \# \s TYPE \s es_index_querycache_memory_size_bytes \s gauge \n
         (
           es_index_querycache_memory_size_bytes\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -94,7 +94,7 @@
         \# \s TYPE \s es_index_querycache_miss_number \s gauge \n
         (
           es_index_querycache_miss_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -106,7 +106,7 @@
         \# \s TYPE \s es_index_querycache_total_number \s gauge \n
         (
           es_index_querycache_total_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_17_index_fieldata.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_17_index_fieldata.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_fielddata_memory_size_bytes \s gauge \n
         (
           es_index_fielddata_memory_size_bytes\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_fielddata_evictions_count \s gauge \n
         (
           es_index_fielddata_evictions_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_18_index_completion.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_18_index_completion.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_completion_size_bytes \s gauge \n
         (
           es_index_completion_size_bytes\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_19_index_segments.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_19_index_segments.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_segments_number \s gauge \n
         (
           es_index_segments_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_segments_memory_bytes \s gauge \n
         (
           es_index_segments_memory_bytes\{
-              cluster="PrometheusExporterITCluster",type="(all|bitset|docvalues|indexwriter|norms|storefields|terms|termvectors|versionmap|points)",index="twitter",context="(primaries|total)"
+              cluster="integTest",type="(all|bitset|docvalues|indexwriter|norms|storefields|terms|termvectors|versionmap|points)",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){20}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_20_index_suggest.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_20_index_suggest.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_suggest_current_number \s gauge \n
         (
           es_index_suggest_current_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_suggest_count \s gauge \n
         (
           es_index_suggest_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -58,7 +58,7 @@
         \# \s TYPE \s es_index_suggest_time_seconds \s gauge \n
         (
           es_index_suggest_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_21_index_requestcache.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_21_index_requestcache.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_requestcache_memory_size_bytes \s gauge \n
         (
           es_index_requestcache_memory_size_bytes\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_requestcache_hit_count \s gauge \n
         (
           es_index_requestcache_hit_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -58,7 +58,7 @@
         \# \s TYPE \s es_index_requestcache_miss_count \s gauge \n
         (
           es_index_requestcache_miss_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -70,7 +70,7 @@
         \# \s TYPE \s es_index_requestcache_evictions_count \s gauge \n
         (
           es_index_requestcache_evictions_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_22_index_recovery.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_22_index_recovery.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_recovery_current_number \s gauge \n
         (
           es_index_recovery_current_number\{
-              cluster="PrometheusExporterITCluster",type="(source|target)",index="twitter",context="(primaries|total)"
+              cluster="integTest",type="(source|target)",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){4}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_recovery_throttle_time_seconds \s gauge \n
         (
           es_index_recovery_throttle_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_23_index_translog.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_23_index_translog.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_translog_operations_number \s gauge \n
         (
           es_index_translog_operations_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_translog_size_bytes \s gauge \n
         (
           es_index_translog_size_bytes\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -58,7 +58,7 @@
         \# \s TYPE \s es_index_translog_uncommitted_operations_number \s gauge \n
         (
           es_index_translog_uncommitted_operations_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -70,7 +70,7 @@
         \# \s TYPE \s es_index_translog_uncommitted_size_bytes \s gauge \n
         (
           es_index_translog_uncommitted_size_bytes\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/30_24_index_warmer.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/30_24_index_warmer.yml
@@ -34,7 +34,7 @@
         \# \s TYPE \s es_index_warmer_current_number \s gauge \n
         (
           es_index_warmer_current_number\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -46,7 +46,7 @@
         \# \s TYPE \s es_index_warmer_time_seconds \s gauge \n
         (
           es_index_warmer_time_seconds\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/
@@ -58,7 +58,7 @@
         \# \s TYPE \s es_index_warmer_count \s gauge \n
         (
           es_index_warmer_count\{
-              cluster="PrometheusExporterITCluster",index="twitter",context="(primaries|total)"
+              cluster="integTest",index="twitter",context="(primaries|total)"
           ,\} \s+ \d+\.\d+ \n?
         ){2}
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/40_10_cluster_settings_disk_threshold.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/40_10_cluster_settings_disk_threshold.yml
@@ -23,7 +23,7 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
         es_cluster_routing_allocation_disk_threshold_enabled\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 1\.0 \n?
         .*/
 
@@ -55,7 +55,7 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
         es_cluster_routing_allocation_disk_threshold_enabled\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 0\.0 \n?
         .*/
 
@@ -87,7 +87,7 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
         es_cluster_routing_allocation_disk_threshold_enabled\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 1\.0 \n?
         .*/
 
@@ -120,7 +120,7 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
         es_cluster_routing_allocation_disk_threshold_enabled\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 1\.0 \n?
         .*/
 
@@ -152,7 +152,7 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
         es_cluster_routing_allocation_disk_threshold_enabled\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 1\.0 \n?
         .*/
 
@@ -184,6 +184,6 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_threshold_enabled (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_threshold_enabled \s gauge \n
         es_cluster_routing_allocation_disk_threshold_enabled\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 1\.0 \n?
         .*/

--- a/src/test/resources/rest-api-spec/test/resthandler/40_20_cluster_settings_disk_watermark_bytes.yml
+++ b/src/test/resources/rest-api-spec/test/resthandler/40_20_cluster_settings_disk_watermark_bytes.yml
@@ -28,7 +28,7 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_watermark_low_bytes (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_low_bytes \s gauge \n
         es_cluster_routing_allocation_disk_watermark_low_bytes\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 1\.0 \n?
         .*/
 
@@ -38,7 +38,7 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_watermark_high_bytes (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_high_bytes \s gauge \n
         es_cluster_routing_allocation_disk_watermark_high_bytes\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 1\.0 \n?
         .*/
 
@@ -48,7 +48,7 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_watermark_flood_stage_bytes (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_flood_stage_bytes \s gauge \n
         es_cluster_routing_allocation_disk_watermark_flood_stage_bytes\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 1\.0 \n?
         .*/
 
@@ -117,7 +117,7 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_watermark_low_pct (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_low_pct \s gauge \n
         es_cluster_routing_allocation_disk_watermark_low_pct\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 99\.9 \n?
         .*/
 
@@ -127,7 +127,7 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_watermark_high_pct (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_high_pct \s gauge \n
         es_cluster_routing_allocation_disk_watermark_high_pct\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 99\.9 \n?
         .*/
 
@@ -137,7 +137,7 @@
         \# \s HELP \s es_cluster_routing_allocation_disk_watermark_flood_stage_pct (\s|\w|\d)+ \n
         \# \s TYPE \s es_cluster_routing_allocation_disk_watermark_flood_stage_pct \s gauge \n
         es_cluster_routing_allocation_disk_watermark_flood_stage_pct\{
-            cluster="PrometheusExporterITCluster"
+            cluster="integTest"
         \,} \s 99\.9 \n?
         .*/
 


### PR DESCRIPTION
Due to internal changes in ES test support we have to rename name of the integration test cluster. Also we have to add several hacks into build.gradle script. All is documented with links to resources. Hopefully one day all hacks will go away.

Closes #234
Successor of #235