### PR TITLE
Upgrade to ES 7.6.0 and release 7.6.0.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: "gradle:5.6.2-jdk12"
+image: "gradle:6.1.1-jdk13"
 
 variables:
   GRADLE_OPTS: "-Dorg.gradle.daemon=false"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
+| 7.6.0          | 7.6.0.0        | Feb 12, 2020 |
 | 7.5.2          | 7.5.2.0        | Jan 25, 2020 |
 | 7.5.1          | 7.5.1.0        | Jan 21, 2020 |
 | 7.5.0          | 7.5.0.0        | Jan 16, 2020 |
@@ -145,7 +146,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
 ## Install
 
 - Since Elasticsearch 7.0.0 :
-    `./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/7.5.2.0/prometheus-exporter-7.5.2.0.zip`
+    `./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/7.6.0.0/prometheus-exporter-7.6.0.0.zip`
 
 - Since Elasticsearch 6.0.0 :
     `./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/6.8.0.0/prometheus-exporter-6.8.0.0.zip`

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,5 @@
 import com.github.mgk.gradle.*
 
-// ------ TODO(lukas-vlcek): Hack should be removed when possible ------
-// See https://github.com/elastic/elasticsearch/issues/49787#issuecomment-567397768
-import org.elasticsearch.gradle.testclusters.TestClustersRegistry
-import org.elasticsearch.gradle.testclusters.TestClustersPlugin
-// ------
-
 buildscript {
     ext {
         es_version = version.replaceAll(/\.[0-9]+(|-SNAPSHOT)$/, "")
@@ -170,11 +164,3 @@ task release() {
         dependsOn(["githubRelease"])
     }
 }
-
-// ------ TODO(lukas-vlcek): Hack should be removed when possible ------
-// See https://github.com/elastic/elasticsearch/issues/49787#issuecomment-567397768
-TestClustersRegistry registry = project.rootProject.extensions.create("testClustersRegistry", TestClustersRegistry)
-TestClustersPlugin.configureClaimClustersHook(project.gradle, registry)
-TestClustersPlugin.configureStartClustersHook(project.gradle, registry)
-TestClustersPlugin.configureStopClustersHook(project.gradle, registry)
-// ------

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.elasticsearch.plugin.prometheus
 
-version = 7.5.2.1-SNAPSHOT
+version = 7.6.0.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.elasticsearch.plugin.prometheus.PrometheusExporterPlugin


### PR DESCRIPTION
- This build requires Java 13 and Gradle 6.1.1+
- Removing the rest of hack https://github.com/elastic/elasticsearch/issues/49787#issuecomment-567397768

Closes #252