### PR TITLE
Upgrade to Elasticsearch 7.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
+| 7.9.0          | 7.9.0.0        | Aug 18, 2020 |
 | 7.8.1          | 7.8.1.0        | Aug 10, 2020 |
 | 7.8.0          | 7.8.0.0        | Jun 22, 2020 |
 | 7.7.1          | 7.7.1.0        | Jun 04, 2020 |
@@ -52,7 +53,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
 
 ## Install
 
-`./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/7.8.1.0/prometheus-exporter-7.8.1.0.zip`
+`./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/7.9.0.0/prometheus-exporter-7.9.0.0.zip`
 
 **Do not forget to restart the node after the installation!**
 
@@ -146,7 +147,7 @@ framework.
 
 To run everything similar to the gitlab pipeline you can do:
 ```
-docker run -v $(pwd):/home/gradle gradle:6.2.1-jdk13 su gradle -c 'gradle check'
+docker run -v $(pwd):/home/gradle gradle:6.6.0-jdk14 su gradle -c 'gradle check'
 ```
 NOTE: Please keep version in sync with .gitlab-ci.yml
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.elasticsearch.plugin.prometheus
 
-version = 7.8.1.1-SNAPSHOT
+version = 7.9.0.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.elasticsearch.plugin.prometheus.PrometheusExporterPlugin


### PR DESCRIPTION
Fixes #284 

A try at updating for Elasticsearch 7.9.0. Was able to run the tests in the README, but had to upgrade to Gradle 6.6.0 after running into:

```
✗ docker run -v $(pwd):/home/gradle gradle:6.2.1-jdk13 su gradle -c 'gradle check'
Unable to find image 'gradle:6.2.1-jdk13' locally
6.2.1-jdk13: Pulling from library/gradle
423ae2b273f4: Pull complete
de83a2304fa1: Pull complete
f9a83bce3af0: Pull complete
b6b53be908de: Pull complete
d6eb45629ecf: Pull complete
9c4bc8753daf: Pull complete
af6d9eabc40c: Pull complete
f3f57dc5eea8: Pull complete
47878241187b: Pull complete
Digest: sha256:d85e7236ec4ef948eef1c6b05c7da74f923039f1c9781f1c61147f7ebb09d262
Status: Downloaded newer image for gradle:6.2.1-jdk13

Welcome to Gradle 6.2.1!

Here are the highlights of this release:
 - Dependency checksum and signature verification
 - Shareable read-only dependency cache
 - Documentation links in deprecation messages

For more details see https://docs.gradle.org/6.2.1/release-notes.html

Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* Where:
Build file '/home/gradle/build.gradle' line: 31

* What went wrong:
A problem occurred evaluating root project 'prometheus-exporter'.
> Failed to apply plugin [class 'org.elasticsearch.gradle.info.GlobalBuildInfoPlugin']
   > Gradle 6.5+ is required

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 15s
```

And then on top of that, Gradle did not have a jdk13 version for anything above 6.5, so it's using jdk14. Unsure if these things are fine or not, or even what to check other than running the tests.

The only other interesting bit was that 7.9.0 added [indexing pressure metrics](https://github.com/elastic/elasticsearch/issues/59263) that I was interested in, but am unsure if testing for those should be set up or if they even will show up in the prometheus metrics endpoint.