### PR TITLE
Upgrade to ES 7.9.3 and release version 7.9.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
 
 | Elasticsearch  | Plugin         | Release date |
 | -------------- | -------------- | ------------ |
+| 7.9.3          | 7.9.3.0        | Oct 22, 2020 |
 | 7.9.2          | 7.9.2.0        | Oct 04, 2020 |
 | 7.9.1          | 7.9.1.0        | Sep 06, 2020 |
 | 7.9.0          | 7.9.0.0        | Aug 18, 2020 |
@@ -55,7 +56,7 @@ It collects all relevant metrics and makes them available to Prometheus via the 
 
 ## Install
 
-`./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/7.9.2.0/prometheus-exporter-7.9.2.0.zip`
+`./bin/elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/7.9.3.0/prometheus-exporter-7.9.3.0.zip`
 
 **Do not forget to restart the node after the installation!**
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = org.elasticsearch.plugin.prometheus
 
-version = 7.9.2.1-SNAPSHOT
+version = 7.9.3.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.elasticsearch.plugin.prometheus.PrometheusExporterPlugin


### PR DESCRIPTION
Hello!

Ran `gradle check` and `gradle clean check` - both commands output very similar things as running it with 7.9.2.1-SNAPSHOT.

Have not tried to build the plugin and install it in a running elasticsearch with 7.9.3.

```
$ docker run -v $(pwd):/home/gradle gradle:6.6.0-jdk14 su gradle -c 'gradle clean check'
SNIP
> Configure project :
Host: 586b2d9d07d0/172.17.0.2
Gradle: 6.6 JVM: 14.0.2 (AdoptOpenJDK 14.0.2+12) Groovy: 2.5.12
Build: group: 'org.elasticsearch.plugin.prometheus', name: 'prometheus-exporter', version: '7.9.3.0'
Timestamp: 2020-10-30T09:35:21.026964Z[GMT]
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 6.6
  OS Info               : Linux 5.4.0-52-generic (amd64)
  JDK Version           : 14 (AdoptOpenJDK)
  JAVA_HOME             : /opt/java/openjdk
  Random Testing Seed   : 33ECC8ACCBDDCEE4
  In FIPS 140 mode      : false
=======================================

> Task :clean
> Task :compileJava
> Task :processResources NO-SOURCE
> Task :classes
> Task :copyCheckstyleConf

> Task :checkstyleMain
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCatalog.java:24: Extra separation in import group before 'java.io.IOException' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCatalog.java:30: Extra separation in import group before 'io.prometheus.client.CollectorRegistry' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java:41: Extra separation in import group before 'java.util.HashMap' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java:45: Extra separation in import group before 'io.prometheus.client.Summary' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/elasticsearch/action/ClusterStatsData.java:21: Extra separation in import group before 'org.elasticsearch.ElasticsearchParseException' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/elasticsearch/action/ClusterStatsData.java:32: Extra separation in import group before 'java.io.IOException' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/elasticsearch/action/NodePrometheusMetricsRequest.java:23: Extra separation in import group before 'java.io.IOException' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/elasticsearch/action/NodePrometheusMetricsResponse.java:31: Extra separation in import group before 'java.io.IOException' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/elasticsearch/action/admin/indices/stats/PackageAccessHelper.java:21: Extra separation in import group before 'java.io.IOException' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/elasticsearch/plugin/prometheus/PrometheusExporterPlugin.java:22: Extra separation in import group before 'org.apache.logging.log4j.LogManager' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/elasticsearch/plugin/prometheus/PrometheusExporterPlugin.java:38: Extra separation in import group before 'java.util.Arrays' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/elasticsearch/rest/prometheus/RestPrometheusMetricsAction.java:23: Extra separation in import group before 'org.apache.logging.log4j.LogManager' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/elasticsearch/rest/prometheus/RestPrometheusMetricsAction.java:37: Extra separation in import group before 'java.util.List' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/elasticsearch/rest/prometheus/RestPrometheusMetricsAction.java:40: Extra separation in import group before 'java.util.Arrays.asList' [ImportOrder]
[ant:checkstyle] [WARN] /home/gradle/src/main/java/org/elasticsearch/rest/prometheus/RestPrometheusMetricsAction.java:40: Wrong order for 'java.util.Arrays.asList' import. [ImportOrder]
Checkstyle rule violations were found. See the report at: file:///home/gradle/build/reports/checkstyle/main.xml
Checkstyle files with violations: 8
Checkstyle violations by severity: [warning:15]


> Task :copyPluginPropertiesTemplate
> Task :pluginProperties
> Task :compileTestJava
> Task :copyYamlTestsTask NO-SOURCE
> Task :copyRestApiSpecsTask
> Task :processTestResources
> Task :testClasses
> Task :checkstyleTest
> Task :forbiddenApisResources
> Task :forbiddenApisMain
> Task :forbiddenApisTest
> Task :forbiddenApis
> Task :checkstyle
> Task :dependencyLicenses SKIPPED
> Task :filepermissions
> Task :forbiddenPatterns
> Task :jarHell
> Task :licenseHeaders
> Task :loggerUsageCheck
> Task :testingConventions
> Task :thirdPartyAuditResources
> Task :thirdPartyAudit SKIPPED
> Task :generatePomFileForNebulaPublication
> Task :validateNebulaPom SKIPPED
> Task :validatePom UP-TO-DATE
> Task :precommit
> Task :test SKIPPED
> Task :generateNotice
> Task :jar
> Task :bundlePlugin
> Task :extractElasticsearch7.9.3
> Task :integTestRunner
> Task :integTest
> Task :javadoc
> Task :check

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.6/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2m 32s
27 actionable tasks: 27 executed
```