### PR TITLE
Rename label for delayed unassigned shards

### DIFF
--- a/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
+++ b/src/main/java/org/compuscene/metrics/prometheus/PrometheusMetricsCollector.java
@@ -109,7 +109,7 @@ public class PrometheusMetricsCollector {
 
             catalog.setClusterGauge("cluster_shards_number", chr.getActiveShards(), "active");
             catalog.setClusterGauge("cluster_shards_number", chr.getActivePrimaryShards(), "active_primary");
-            catalog.setClusterGauge("cluster_shards_number", chr.getDelayedUnassignedShards(), "unassigned");
+            catalog.setClusterGauge("cluster_shards_number", chr.getDelayedUnassignedShards(), "delayed_unassigned");
             catalog.setClusterGauge("cluster_shards_number", chr.getInitializingShards(), "initializing");
             catalog.setClusterGauge("cluster_shards_number", chr.getRelocatingShards(), "relocating");
             catalog.setClusterGauge("cluster_shards_number", chr.getUnassignedShards(), "unassigned");


### PR DESCRIPTION
Closes #310

This has been tested on my Elasticsearch 7.13.0 cluster deployed using ECK. I have now got unique metrics for unassigned shards and delayed unassigned shards. These can be queried in prometheus using:

`avg(es_cluster_shards_number{cluster="example",type="unassigned"})`

and

`avg(es_cluster_shards_number{cluster="example",type="delayed_unassigned"})`

I've also produced a simple dashboard that works for the current metrics/labels. Please let me know if you want this PR'ed in to the repo.